### PR TITLE
Ungroup input data

### DIFF
--- a/R/tbl_xts.R
+++ b/R/tbl_xts.R
@@ -27,7 +27,7 @@
 tbl_xts <- function(tblData, cols_to_xts, spread_by, spread_name_pos, Colnames_Exact = FALSE) {
 
   # Sanity Checks -----------------------------------------------------------
-
+  tblData <- tblData %>% ungroup()
   cols_xts <- enquo( cols_to_xts )
   spreader <- enquo( spread_by )
   spreadCol = NULL


### PR DESCRIPTION
If the input data is grouped, dplyr will also include the grouping variable when selecting on line 34, ` N_xts_Cols <- tblData %>% select(!!cols_xts) %>% ncol()`. So even though `cols_to_xts` is just one variable, dplyr will also include the grouping variable in this selection so the result of `ncol()` will be 2, not 1. This will trigger the enforced suffix on line 41, even though the length of `cols_to_xts` is 1. Ungrouping all input data by default fixes this issue.