### PR TITLE
adjust class checks to generalise to accommodate quanstrat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: tbl2xts
-Version: 1.0.4
+Version: 1.0.5
 Date: 2021-01-09
 Type: Package
 Title: Convert Tibbles or Data Frames to Xts Easily

--- a/R/xts_tbl.R
+++ b/R/xts_tbl.R
@@ -20,7 +20,8 @@ xts_tbl <- function(xts, Colnames_Exact = FALSE) {
 
   # Sanity Check -----------------------------------------------------------
   # ensure that column 1 is a valid date column:
-  if ( class(xts)[1] !=  "xts") stop("Ensure that the supplied dataframe has class xts...")
+  if ( !inherits(xts, "xts") )
+       stop("Ensure that the supplied dataframe has class xts...")
 
   Names <- colnames(coredata(xts))
   df <- data.frame(date=index(xts), coredata(xts)) %>% tibble::as_tibble()


### PR DESCRIPTION
# Why 

Using an absolute check for classes break more complex data structures, especially in `quantstrat`.

# What

Adjust class checks to generalise to accommodate `quanstrat` construct.